### PR TITLE
Define _GNU_SOURCE conditionally.

### DIFF
--- a/src/pyq.c
+++ b/src/pyq.c
@@ -1,5 +1,7 @@
 #ifdef __linux__
-#  define _GNU_SOURCE
+#  ifndef _GNU_SOURCE
+#    define _GNU_SOURCE
+#  endif
 #endif
 
 #include <unistd.h>


### PR DESCRIPTION
It failed to install on centos 7 with the following error: (Might because cc1: all warnings being treated as errors)

    gcc -pthread -Wno-unused-result -Wsign-compare -Wunreachable-code -DNDEBUG -O2 -g -pipe -Wall -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector-strong --param=ssp-buffer-size=4 -grecord-gcc-switches -m64 -mtune=generic -D_GNU_SOURCE -fPIC -fwrapv -I/opt/rh/rh-python35/root/usr/include -O2 -g -pipe -Wall -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector-strong --param=ssp-buffer-size=4 -grecord-gcc-switches -m64 -mtune=generic -D_GNU_SOURCE -fPIC -fwrapv -fPIC -DKXVER=3 -DKXVER2=5 -DPY3K=35 -Isrc/pyq -c src/pyq/p.c -o build/temp.linux-x86_64/src/pyq/p.o -Wpointer-arith -Werror -fno-strict-aliasing
    creating build/qext.linux-x86_64                
    gcc -pthread -shared -L/opt/rh/rh-python35/root/usr/lib64-Wl,-z,relro build/temp.linux-x86_64/src/pyq/p.o -o build/qext.linux-x86_64/p.so                                                                    
    running build_exe                               
    gcc -pthread -Wno-unused-result -Wsign-compare -Wunreachable-code -DNDEBUG -O2 -g -pipe -Wall -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector-strong --param=ssp-buffer-size=4 -grecord-gcc-switches -m64 -mtune=generic -D_GNU_SOURCE -fPIC -fwrapv -I/opt/rh/rh-python35/root/usr/include -O2 -g -pipe -Wall -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector-strong --param=ssp-buffer-size=4 -grecord-gcc-switches -m64 -mtune=generic -D_GNU_SOURCE -fPIC -fwrapv -fPIC -DKXVER=3 -DQARCH=l32 -c src/pyq.c -o src/pyq.o -Wpointer-arith -Werror -fno-strict-aliasing
    src/pyq.c:2:0: error: "_GNU_SOURCE" redefined [-Werror]                                             
     #  define _GNU_SOURCE                          
     ^                                              
    <command-line>:0:0: note: this is the location of the previous definition                           
    cc1: all warnings being treated as errors       
    error: command 'gcc' failed with exit status 1