### PR TITLE
Handle oserror for missing ldconfig in path

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -253,7 +253,7 @@ def get_python_dll(executable):
         libpython = 'libpython{}.{}'.format(*sys.version_info[:2]).encode()
         try:
             output = subprocess.check_output(['ldconfig', '-p'])
-        except subprocess.CalledProcessError:
+        except (subprocess.CalledProcessError, OSError):
             output = subprocess.check_output(['/sbin/ldconfig', '-p'])
         for line in output.splitlines():
             if libpython in line:


### PR DESCRIPTION
Currently when ldconfig is not in the path the
code looks for exception subprocess.CalledProcessError but
the real exception emitted is that of OSError. In this
patch I leave the existing subprocess.CalledProcessError and
append OSError to it.